### PR TITLE
[TASK] Set xdebug.max_nesting_level to 1000

### DIFF
--- a/docker/typo3/conf/php.ini
+++ b/docker/typo3/conf/php.ini
@@ -17,3 +17,4 @@ xdebug.remote_enable = 1
 xdebug.remote_connect_back = on
 xdebug.idekey = "docker"
 xdebug.cli_color = 1
+xdebug.max_nesting_level = 1000


### PR DESCRIPTION
This solves the issue with Extbase and Fluid having too many nested objects
