### PR TITLE
To make the dockerfile build I need to create a dir before making it a volume.

### DIFF
--- a/docker/main/Ubuntu-14.04
+++ b/docker/main/Ubuntu-14.04
@@ -55,6 +55,7 @@ COPY conf/ubuntu        /opt/docker/conf/
 
 EXPOSE 9000
 
+RUN mkdir -p /docker/code/
 VOLUME /docker/
 WORKDIR /docker/code/
 


### PR DESCRIPTION
See documentation: https://docs.docker.com/reference/builder/#volume

Tested under Virtualbox. Please consider to test the patch with parallels before.

This partly solves #75.
