### PR TITLE
mysqldump: also backup routines, functions and the comments in them

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -25,7 +25,7 @@ case "$1" in
         fi
 
         logMsg "Starting MySQL backup..."
-        mysqldump --opt --single-transaction --events --all-databases | bzip2 > "${BACKUP_DIR}/${BACKUP_MYSQL_FILE}"
+        mysqldump --opt --single-transaction --events --all-databases --routines --comments | bzip2 > "${BACKUP_DIR}/${BACKUP_MYSQL_FILE}"
         ;;
 
     ###################################


### PR DESCRIPTION
Routines and functions are essential parts of the database. The comments are the documentation of the code. Unfortunately _mysqldump_ excludes all of this by default. So let's include it. 

https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html
