### PR TITLE
Make the Makefile more user friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 ARGS = $(filter-out $@,$(MAKECMDGOALS))
+MAKEFLAGS += --silent
 
-all: build
+list:
+	sh -c "echo; $(MAKE) -p no_targets__ | awk -F':' '/^[a-zA-Z0-9][^\$$#\/\\t=]*:([^=]|$$)/ {split(\$$1,A,/ /);for(i in A)print A[i]}' | grep -v '__\$$' | grep -v 'Makefile'| sort"
 
 #############################
 # Create new project


### PR DESCRIPTION
- Target list lists the targets of the makefile.
- Make list the default target.
- Remove the old default target all.
- Silence the command calls.

When called as make without target, the available targets are listed.
This behaviour goes in the direction of rake.
