### PR TITLE
Add links to Vagrant and Docker

### DIFF
--- a/documentation/INSTALL.md
+++ b/documentation/INSTALL.md
@@ -4,7 +4,7 @@
 
 ## Reqirements
 
-- GNU/Linux with Docker (recommendation: Vagrant VM with Docker or native Linux with Docker)
+- GNU/Linux with Docker (recommendation: [Vagrant](https://www.vagrantup.com/downloads.html) VM with Docker or [native Linux with Docker](http://docs.docker.com/linux/step_one/)
 - make
 - [composer](https://getcomposer.org/)
 - [docker-compose](https://github.com/docker/compose)


### PR DESCRIPTION
Add links to install instructions for Vagrant and Docker, so that you have a shortcut to the correct pages. This makes it easier for beginners to find the correct instructions.
