### PR TITLE
Switch to docker exec in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ rebuild:
 #############################
 
 mysql-backup:
-	docker-compose run --rm --no-deps app root bash /docker/bin/backup.sh mysql
+	docker exec -it $$(docker-compose ps -q app) bash /docker/bin/backup.sh mysql
 
 mysql-restore:
-	docker-compose run --rm --no-deps app root bash /docker/bin/restore.sh mysql
+	docker exec -it $$(docker-compose ps -q app) bash /docker/bin/restore.sh mysql
 
 #############################
 # Solr
@@ -49,12 +49,12 @@ mysql-restore:
 
 solr-backup:
 	docker-compose stop solr
-	docker-compose run --rm --no-deps app root bash /docker/bin/backup.sh solr
+	docker exec -it $$(docker-compose ps -q app) bash /docker/bin/backup.sh solr
 	docker-compose start solr
 
 solr-restore:
 	docker-compose stop solr
-	docker-compose run --rm --no-deps app root bash /docker/bin/restore.sh solr
+	docker exec -it $$(docker-compose ps -q app) bash /docker/bin/restore.sh solr
 	docker-compose start solr
 
 #############################
@@ -71,17 +71,17 @@ clean:
 	test -d app/typo3temp && { rm -rf app/typo3temp/*; }
 
 bash:
-	docker-compose run --rm app bash
+	docker exec -it $$(docker-compose ps -q app) bash
 
 root:
-	docker-compose run --rm app root
+	docker exec -it $$(docker-compose ps -q app) bash
 
 #############################
 # TYPO3
 #############################
 
 scheduler:
-	docker-compose run --rm app typo3/cli_dispatch.phpsh scheduler $(ARGS)
+	docker exec -it $$(docker-compose ps -q app) typo3/cli_dispatch.phpsh scheduler $(ARGS)
 
 #############################
 # Argument fix workaround


### PR DESCRIPTION
I tried using the command `make mysql-backup` and `make bash` but I only got the following message:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{HTTPD_VARS}}'). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{http_conf_list.stdout_lines}}'). This feature will be removed in a future release. Deprecation warnings can be disabled by setting  deprecation_warnings=False in ansible.cfg.
Executing entrypoint "root"
```

I didn't read all the Docker documentation, but I think `docker-compose run --rm` is the reason why it's not working. Using `docker exec -it` is more recent and it worked for me, so I decided to adapt the `Makefile`
