### PR TITLE
enable phpXdebug by default for dev environment

### DIFF
--- a/etc/application.development.yml
+++ b/etc/application.development.yml
@@ -5,7 +5,7 @@ PROVISION:
 
   install:
     phpBlackfire:       false
-    phpXdebug:          false
+    phpXdebug:          true
     apacheModPagespeed: false
 
   service:


### PR DESCRIPTION
the php development.ini has xdebug enabled by default, so xdebug should also be installed.
alternative: update the docs, that you have to enable phpXdebug first.
