### PR TITLE
[TASK] switch to mailhog

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: Dockerfile.development
     links:
-      - mailcatcher
+      - mailhog
       - mysql
       #- postgres
       #- solr
@@ -132,14 +132,14 @@ services:
   #    - etc/environment.development.yml
 
   #######################################
-  # Mailcatcher
+  # Mailhog
   #######################################
-  mailcatcher:
-    image: schickling/mailcatcher
+  mailhog:
+    image: mailhog/mailhog
     ports:
-      - 1080:1080
+      - 8025:8025
     environment:
-      - VIRTUAL_HOST=mailcatcher.docker
+      - VIRTUAL_HOST=mailhog.docker
 
   #######################################
   # FTP (vsftpd)


### PR DESCRIPTION
Mailhog is written in go and has a much lower footprint than mailcatcher.
It also offers an API to automatically check for mails in tests and
it doesn't randomly stack up memory usage and crash.
