### PR TITLE
[TASK] Update documentation for running typo3

### DIFF
--- a/documentation/PROJECT-TYPO3.md
+++ b/documentation/PROJECT-TYPO3.md
@@ -20,7 +20,7 @@ touch app/web/FIRST_INSTALL app/.gitkeep
 
 Open <http://localhost:8000> and follow installation wizard.
 
-When asked for database setup, use the settings from the [services documentation](https://github.com/webdevops/TYPO3-docker-boilerplate/blob/master/documentation/SERVICES.md#mysql) or see your etc/environment.yml. Make sure to set the correct database-host ('mysql' by default). 
+When asked for database setup, use the settings from the [services documentation](https://github.com/webdevops/TYPO3-docker-boilerplate/blob/master/documentation/SERVICES.md#mysql) or see your `etc/environment.yml`. Make sure to set the correct database-host ('mysql' by default). 
 
 
 Feel free to modify your TYPO3 installation in your `app/` (a shared folder of Docker),

--- a/documentation/PROJECT-TYPO3.md
+++ b/documentation/PROJECT-TYPO3.md
@@ -4,19 +4,24 @@
 
 ## Create TYPO3 project
 
-For the first TYPO3 setup (make sure [composer](https://getcomposer.org/) is installed):
+For the first TYPO3 setup:
 
 ```bash
 make create typo3
 ```
 
-or
+or (make sure [composer](https://getcomposer.org/) is installed)
 
 ```bash
 rm -f app/.gitkeep
 composer create-project typo3/cms-base-distribution app/
-touch app/FIRST_INSTALL app/.gitkeep
+touch app/web/FIRST_INSTALL app/.gitkeep
 ```
+
+Open <http://localhost:8000> and follow installation wizard.
+
+When asked for database setup, use the settings from the [services documentation](https://github.com/webdevops/TYPO3-docker-boilerplate/blob/master/documentation/SERVICES.md#mysql) or see your etc/environment.yml. Make sure to set the correct database-host ('mysql' by default). 
+
 
 Feel free to modify your TYPO3 installation in your `app/` (a shared folder of Docker),
 most of the time there is no need to enter any Docker container.
@@ -27,16 +32,17 @@ most of the time there is no need to enter any Docker container.
 You can run one-shot command inside the `app` service container:
 
 ```bash
-docker-compose run --rm app typo3/cli_dispatch.phpsh scheduler
+docker-compose run --rm app web/typo3/cli_dispatch.phpsh extbase
+# or simply:
+docker-compose run --rm app cli extbase   # cli refers to CLI_SCRIPT env in etc/environment.yml
+
 docker-compose run --rm app bash
 ```
-
-Webserver is available at Port 8000
 
 
 ## Error: Trusted Host pattern
 
-Set in htdocs/typo3conf/LocalConfiguration.php:
+Set in web/typo3conf/LocalConfiguration.php:
 
     'SYS' => array(
         [ ... ],


### PR DESCRIPTION
- Fix pathes
- Use 'extbase' command as example for typo3 cli call instead of 'scheduler' which will throw an error when following the steps in this doc, because EXT:scheduler is not activated in default typo3 installation
- Add cli shortcut example
- Add notes about installation wizard and credentials