### PR TITLE
[TASK] Use docker-compose exec for make shell/root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ clean:
 bash: shell
 
 shell:
-	docker exec -it -u application $$(docker-compose ps -q app) /bin/bash
+	docker-compose exec --user application app /bin/bash
 
 root:
-	docker exec -it -u root $$(docker-compose ps -q app) /bin/bash
+	docker-compose exec --user root app /bin/bash
 
 #############################
 # TYPO3


### PR DESCRIPTION
Use docker-compose exec instead of docker exec for
'make shell' respectively 'make bash' and 'make root'.

This also speeds up these commands, because it is not necessary
to determine the container id for the app container anymore.