### PR TITLE
[TASK] Fix make scheduler cmd for TYPO3 >6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ root:
 #############################
 
 scheduler:
-	docker exec -it $$(docker-compose ps -q app) typo3/cli_dispatch.phpsh scheduler $(ARGS)
+	# TODO: remove the workaround "; (exit $?)" when https://github.com/docker/compose/issues/3379 has been fixed
+	docker-compose exec --user application app /bin/bash -c '"$$WEB_DOCUMENT_ROOT"typo3/cli_dispatch.phpsh scheduler $(ARGS); (exit $$?)'
 
 #############################
 # Argument fix workaround


### PR DESCRIPTION
- Determine path to typo3/cli_dispatch.phpsh by looking up
  WEB_DOCUMENT_ROOT env variable which is defined in
  etc/environment.yml and automatically available in
  the app container.
  This makes the 'make scheduler' command work for all
  TYPO3 versions.
- Run container as application user to avoid permission problems.
- Use docker-compose exec instead of docker exec,
  which speeds up the command call, because there is no
  need to determine the container id of the app container
  anymore.

Fixes #139