### PR TITLE
[BUGFIX] Variables with spaces in etc/environment.yml break 'make mysql-backup/-restore' commands

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -26,7 +26,7 @@ case "$1" in
             fi
 
             logMsg "Starting MySQL backup..."
-            source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../etc/environment.yml"
+            MYSQL_ROOT_PASSWORD="$(grep "MYSQL_ROOT_PASSWORD" "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../etc/environment.yml" | cut -d "=" -f 2)"
             dockerExec mysqldump -h mysql -u root -p"${MYSQL_ROOT_PASSWORD}" --opt --single-transaction --events --all-databases --routines --comments | bzip2 > "${BACKUP_DIR}/${BACKUP_MYSQL_FILE}"
             logMsg "Finished"
         else

--- a/bin/restore.sh
+++ b/bin/restore.sh
@@ -22,7 +22,7 @@ case "$1" in
         if [[ -n "$(dockerContainerId mysql)" ]]; then
             if [ -f "${BACKUP_DIR}/${BACKUP_MYSQL_FILE}" ]; then
                 logMsg "Starting MySQL restore..."
-                source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../etc/environment.yml"
+                MYSQL_ROOT_PASSWORD="$(grep "MYSQL_ROOT_PASSWORD" "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../etc/environment.yml" | cut -d "=" -f 2)"
                 bzcat "${BACKUP_DIR}/${BACKUP_MYSQL_FILE}" | dockerExec mysql -h mysql -u root -p"${MYSQL_ROOT_PASSWORD}"
                 echo "FLUSH PRIVILEGES;" | dockerExec mysql -h mysql -u root -p"${MYSQL_ROOT_PASSWORD}"
                 logMsg "Finished"


### PR DESCRIPTION
The commands 'make mysql-backup' and 'make mysql-restore' read
the MYSQL_ROOT_PASSWORD variable from the etc/environment.yml file.

If any of the variables values in etc/environment.yml contain whitespaces
and are not quoted, these commands failed before.
As this file is mainly used as docker environment file, variable values
are usually not quoted. For some variables (e.g. CLI_SCRIPT) it would
even break functionality when enclosed in quotes.

To avoid this problem, only fetch the single MYSQL_ROOT_PASSWORD
variable, handling unquoted whitespace values probably.