### PR TITLE
[TASK] Pull images on make rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,10 @@ state:
 
 rebuild:
 	docker-compose stop
+	docker-compose pull
 	docker-compose rm --force app
 	docker-compose build --no-cache
-	docker-compose up -d
+	docker-compose up -d --force-recreate
 
 #############################
 # MySQL


### PR DESCRIPTION
Make sure to use latest images by automatically pulling needed images
when using 'make rebuild' and 'make up'.
If utilizing 'make up', images are only pulled if there are no containers
started/stopped/paused, because updated images will be used only
on container (re-)creation.