### PR TITLE
Set MYSQL_HOST and MYSQL_PORT in environment.yml

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -34,6 +34,8 @@ MYSQL_ROOT_PASSWORD=dev
 MYSQL_USER=dev
 MYSQL_PASSWORD=dev
 MYSQL_DATABASE=typo3
+MYSQL_HOST=mysql
+MYSQL_PORT=3306
 
 #######################################
 # PostgreSQL settings


### PR DESCRIPTION
This was missing even though it was already documented in DOCKER-INFO.md.