### PR TITLE
Revert "Fix missing quotation marks in etc/environment.yml"

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -12,7 +12,7 @@
 # General
 WEB_DOCUMENT_ROOT=/app/web/
 WEB_DOCUMENT_INDEX=index.php
-CLI_SCRIPT="php /app/web/typo3/cli_dispatch.phpsh"
+CLI_SCRIPT=php /app/web/typo3/cli_dispatch.phpsh
 
 #######################################
 # SSH settings


### PR DESCRIPTION
This reverts commit 0920887f0df622b326ef44345939f42f5a162c7f
because wrapping the value of CLI_SCRIPT breaks its usage:
    $ docker-compose run --rm app cli help
    sudo: "php: command not found