### PR TITLE
[FEATURE] Add 'make cli' shortcut for TYPO3 cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ root:
 # TYPO3
 #############################
 
+cli:
+	docker-compose run --rm --user application app cli $(ARGS)
+
 scheduler:
 	docker exec -it $$(docker-compose ps -q app) typo3/cli_dispatch.phpsh scheduler $(ARGS)
 


### PR DESCRIPTION
A shortcut for invoking the TYPO3 cli inside the app container.
Allows simple usage of TYPO3 cli commands e.g.:
    $ make cli extbase language:update