### PR TITLE
[FEATURE] Preset mysql server on pma login screen

### DIFF
--- a/docker-compose.development-reverse-proxy.yml
+++ b/docker-compose.development-reverse-proxy.yml
@@ -186,7 +186,7 @@ services:
   #  links:
   #    - mysql
   #  environment:
-  #    - PMA_ARBITRARY=1
+  #    - PMA_HOSTS=mysql
   #    - VIRTUAL_HOST=pma.boilerplate.docker
   #    - VIRTUAL_PORT=80
   #  volumes:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -188,7 +188,7 @@ services:
   #  links:
   #    - mysql
   #  environment:
-  #    - PMA_ARBITRARY=1
+  #    - PMA_HOSTS=mysql
   #    - VIRTUAL_HOST=pma.boilerplate.docker
   #    - VIRTUAL_PORT=80
   #  volumes:


### PR DESCRIPTION
Preset the default hostname of the mysql container by using
the PMA_HOSTS environment variable.
This avoids manually entering the server ('mysql' by default)
on the phpmyadmin login screen.
There will be a selectbox on the login screen to choose a server from,
if multiple servers are given (comma separated) to the PMA_HOSTS env var.