### PR TITLE
[TASK] Pull the base images for the to be build images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ rebuild:
 	docker-compose stop
 	docker-compose pull
 	docker-compose rm --force app
-	docker-compose build --no-cache
+	docker-compose build --no-cache --pull
 	docker-compose up -d --force-recreate
 
 #############################


### PR DESCRIPTION
I recognized that the `docker-compose pull` isn't enough to pull all images during `make rebuild`.
It doesn't pull the images that are specified in the `Dockerfile` of the images that need to be build (app, mysql, etc.).
This patch also pulls the base images that are used to build the service images.