### PR TITLE
[FIX] lock MariaDB version to 10.1

### DIFF
--- a/docker/mysql/MariaDB-10.Dockerfile
+++ b/docker/mysql/MariaDB-10.Dockerfile
@@ -9,6 +9,6 @@
 #
 #++++++++++++++++++++++++++++++++++++++
 
-FROM mariadb:10
+FROM mariadb:10.1
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf


### PR DESCRIPTION
10.2 is not compatible with TYPO3 any more because recursive
is now a reserved keyword (tt_content).

See https://forge.typo3.org/issues/81341