### PR TITLE
Fix database config permissions

### DIFF
--- a/docker/mysql/MariaDB-10.Dockerfile
+++ b/docker/mysql/MariaDB-10.Dockerfile
@@ -12,3 +12,5 @@
 FROM mariadb:10
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/docker/mysql/MariaDB-5.5.Dockerfile
+++ b/docker/mysql/MariaDB-5.5.Dockerfile
@@ -12,3 +12,5 @@
 FROM mariadb:5.5
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/docker/mysql/MySQL-5.5.Dockerfile
+++ b/docker/mysql/MySQL-5.5.Dockerfile
@@ -12,3 +12,5 @@
 FROM mysql:5.5
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/docker/mysql/MySQL-5.6.Dockerfile
+++ b/docker/mysql/MySQL-5.6.Dockerfile
@@ -12,3 +12,5 @@
 FROM mysql:5.6
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/docker/mysql/MySQL-5.7.Dockerfile
+++ b/docker/mysql/MySQL-5.7.Dockerfile
@@ -12,3 +12,5 @@
 FROM mysql:5.7
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/docker/mysql/Percona-5.5.Dockerfile
+++ b/docker/mysql/Percona-5.5.Dockerfile
@@ -12,3 +12,5 @@
 FROM percona:5.5
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/docker/mysql/Percona-5.6.Dockerfile
+++ b/docker/mysql/Percona-5.6.Dockerfile
@@ -12,3 +12,5 @@
 FROM percona:5.6
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/docker/mysql/Percona-5.7.Dockerfile
+++ b/docker/mysql/Percona-5.7.Dockerfile
@@ -12,3 +12,5 @@
 FROM percona:5.7
 
 ADD conf/mysql-docker.cnf /etc/mysql/conf.d/z99-docker.cnf
+RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
+    && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf


### PR DESCRIPTION
Database starts with `config file is ignored 959` because `ADD` sets the permissions to 0755