### PR TITLE
Change server collation to utf8_unicode_ci

### DIFF
--- a/docker/mysql/conf/mysql-docker.cnf
+++ b/docker/mysql/conf/mysql-docker.cnf
@@ -4,7 +4,7 @@
 ## Charset
 
 character-set-server=utf8
-collation-server=utf8_general_ci
+collation-server=utf8_unicode_ci
 
 #################################################
 ## Buffers


### PR DESCRIPTION
For correct sorting of tables with e.g. german umlauts and ß it is recommended to use the server collation utf8_unicode_ci instead of utf8_general_ci.